### PR TITLE
change check on start timestamp

### DIFF
--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -131,10 +131,13 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
                                  << beams_ << " time look up table size is "
                                  << times_lut_.size());
   DEBUG_PRINTLN("minmax times : " << (*minmax_time.first ) << " " << (*minmax_time.second));
-  uint64_t t_start = start_timestamp + (*minmax_time.first );
-  uint64_t t_end =   start_timestamp + (*minmax_time.second);
+  uint64_t t_start = start_timestamp + static_cast<uint64_t>(*minmax_time.first );
+  uint64_t t_end =   start_timestamp + static_cast<uint64_t>(*minmax_time.second);
 
-  if(desired_timestamp < t_start || desired_timestamp > t_end){
+  // Note: Compare to start_timestamp, not t_start since the points may begin
+  // shortly after the start_stamp (e.g. the point could start at 0.1ms after
+  // the point cloud timestamp, leading to this method failing).
+  if(desired_timestamp < start_timestamp || desired_timestamp > t_end){
     ERROR_PRINTLN("[LidarUndistorter] ERROR: the desired timestamp "
                   << "is outside the valid timestamp bounds for the point cloud");
     return false;

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -131,13 +131,16 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
                                  << beams_ << " time look up table size is "
                                  << times_lut_.size());
   DEBUG_PRINTLN("minmax times : " << (*minmax_time.first ) << " " << (*minmax_time.second));
-  uint64_t t_start = start_timestamp + static_cast<uint64_t>(*minmax_time.first );
-  uint64_t t_end =   start_timestamp + static_cast<uint64_t>(*minmax_time.second);
+  uint64_t t_start = static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.first));
+  uint64_t t_end =   static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.second));
 
-  // Note: Compare to start_timestamp, not t_start since the points may begin
-  // shortly after the start_stamp (e.g. the point could start at 0.1ms after
-  // the point cloud timestamp, leading to this method failing).
-  if(desired_timestamp < start_timestamp || desired_timestamp > t_end){
+  if(start_timestamp != t_start){
+    ERROR_PRINTLN("[LidarUndistorter] ERROR: the start timestamp "
+                  << "is different than t_start: " << start_timestamp << " != " << t_start);
+    return false;
+  }
+
+  if(desired_timestamp < t_start || desired_timestamp > t_end){
     ERROR_PRINTLN("[LidarUndistorter] ERROR: the desired timestamp "
                   << "is outside the valid timestamp bounds for the point cloud");
     return false;


### PR DESCRIPTION
@mcamurri 

This changes the check on the timestamps in the undistorter.

This fixes an edge case where we try to undistort the point cloud to a time between the point cloud header time, and the time of the first point in the cloud (see diagram below).

![image](https://user-images.githubusercontent.com/6793487/117287769-9bde5780-ae62-11eb-80e4-205ca2a99ba1.png)
