### PR TITLE
A couple of small fixes

### DIFF
--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -139,9 +139,16 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
     return false;
   }
 
-  if(desired_timestamp < t_start || desired_timestamp > t_end){
+  // 5 ms buffer to account for differences between header stamps and individual
+  // point times
+  const uint64_t buffer = 5000000; // ns
+  if(desired_timestamp < (t_start - buffer) || desired_timestamp > (t_end + buffer)){
     ERROR_PRINTLN("[LidarUndistorter] ERROR: the desired timestamp "
                   << "is outside the valid timestamp bounds for the point cloud");
+    ERROR_PRINTLN("[LidarUndistorter]"
+                  << "\nDesired timestamp: " << desired_timestamp
+                  << "\nStart timestamp  : " << t_start
+                  << "\nEnd timestamp    : " << t_end);
     return false;
   }
 

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -137,10 +137,7 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
     return false;
   }
 
-  // 5 ms buffer to account for differences between header stamps and individual
-  // point times
-  const uint64_t buffer = 5000000; // ns
-  if(desired_timestamp < (t_start - buffer) || desired_timestamp > (t_end + buffer)){
+  if(desired_timestamp < t_start || desired_timestamp > t_end){
     ERROR_PRINTLN("[LidarUndistorter] ERROR: the desired timestamp "
                   << "is outside the valid timestamp bounds for the point cloud");
     ERROR_PRINTLN("[LidarUndistorter]"

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -128,8 +128,8 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
                                  << beams_ << " time look up table size is "
                                  << times_lut_.size());
   DEBUG_PRINTLN("minmax times : " << (*minmax_time.first ) << " " << (*minmax_time.second));
-  uint64_t t_start = static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.first));
-  uint64_t t_end =   static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.second));
+  const uint64_t t_start = static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.first));
+  const uint64_t t_end =   static_cast<uint64_t>(static_cast<int64_t>(start_timestamp) + static_cast<int64_t>(*minmax_time.second));
 
   if(start_timestamp != t_start){
     ERROR_PRINTLN("[LidarUndistorter] ERROR: the start timestamp "
@@ -218,13 +218,16 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
   int32_t last_transform_update_t = 0;
 
   Eigen::Isometry3d T_S_original_S_corrected = Eigen::Isometry3d::Identity();
+  const Eigen::Isometry3d T_S_F_original_inverse = T_S_F_original.inverse(); // precompute
   size_t point_counter = 0;
   for (auto &point : pointcloud->points) {
     // Check if the current point's timestamp differs from the previous one
     // If so, lookup the new corresponding transform
     if (times_lut_[point_counter] != last_transform_update_t) {
       last_transform_update_t = times_lut_[point_counter];
-      uint64_t point_t = start_timestamp + times_lut_[point_counter];
+      const uint64_t point_t = static_cast<uint64_t>(
+          static_cast<int64_t>(start_timestamp) +
+          static_cast<int64_t>(times_lut_[point_counter]));
 
       Eigen::Isometry3d T_F_S_correct;
       if(!odometry_history_.getInterpolatedPose(point_t, T_F_S_correct)){
@@ -245,7 +248,7 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
         DEBUG_PRINTLN("Adding interpolated pose to pose history"
                         << "\n Pose history size: " << odometry_history_.size());
       }
-      T_S_original_S_corrected = T_S_F_original.inverse() * T_F_S_correct;
+      T_S_original_S_corrected = T_S_F_original_inverse * T_F_S_correct;
     }
 
     // Correct the point's distortion, by transforming it into the fixed

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -244,9 +244,13 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
       } else {
         // add the just computed interpolated pose to the buffer of poses
         // in case we need it later
-        odometry_history_.addPose(point_t, T_F_S_correct);
-        DEBUG_PRINTLN("Adding interpolated pose to pose history"
-                        << "\n Pose history size: " << odometry_history_.size());
+        static constexpr bool SAVE_POSES_FOR_LATER = false;
+        if (SAVE_POSES_FOR_LATER) {
+          odometry_history_.addPose(point_t, T_F_S_correct);
+          DEBUG_PRINTLN("Adding interpolated pose to pose history"
+                        << "\n Pose history size: "
+                        << odometry_history_.size());
+        }
       }
       T_S_original_S_corrected = T_S_F_original_inverse * T_F_S_correct;
     }

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -216,10 +216,11 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
   // Correct the distortion on all points, using the LiDAR's true pose at
   // each point's timestamp
   int32_t last_transform_update_t = 0;
-
+  Eigen::Isometry3d T_F_S_correct = Eigen::Isometry3d::Identity();
   Eigen::Isometry3d T_S_original_S_corrected = Eigen::Isometry3d::Identity();
   const Eigen::Isometry3d T_S_F_original_inverse = T_S_F_original.inverse(); // precompute
   size_t point_counter = 0;
+
   for (auto &point : pointcloud->points) {
     // Check if the current point's timestamp differs from the previous one
     // If so, lookup the new corresponding transform
@@ -229,7 +230,6 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
           static_cast<int64_t>(start_timestamp) +
           static_cast<int64_t>(times_lut_[point_counter]));
 
-      Eigen::Isometry3d T_F_S_correct;
       if(!odometry_history_.getInterpolatedPose(point_t, T_F_S_correct)){
         DEBUG_PRINTLN("Couldn't get interpolated point pose for time " << point_t
                         << "\n Starting time: " << (odometry_history_.empty() ? std::string("none") : std::to_string(odometry_history_.startTime()))
@@ -264,7 +264,7 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
     point.y = pointTransformed[1];
     point.z = pointTransformed[2];
 
-    point_counter++;
+    ++point_counter;
   }
   return true;
 }

--- a/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/lidar_undistorter.hpp
@@ -1,14 +1,12 @@
 #ifndef LIDAR_UNDISTORTION_LIDAR_UNDISTORTER_H_
 #define LIDAR_UNDISTORTION_LIDAR_UNDISTORTER_H_
 
-#include <Eigen/Eigen>
+#include <Eigen/Geometry>
 #include <string>
 #include <pcl/point_cloud.h>
-#include <pcl/common/transforms.h>
 #include "lidar_undistortion/pose_buffer.hpp"
 #include "lidar_undistortion/print_macros.hpp"
 #include <algorithm>
-#include <pcl/io/pcd_io.h>
 
 namespace lidar_undistortion {
 
@@ -256,7 +254,12 @@ inline bool LidarUndistorter<PointT>::processCloud(const typename PointCloud::Pt
     // Correct the point's distortion, by transforming it into the fixed
     // frame based on the LiDAR sensor's current true pose, and then transform
     // it back into the lidar scan frame
-    point = pcl::transformPoint(point, T_S_original_S_corrected.cast<float>());
+    const Eigen::Vector3d pointTransformed =
+        T_S_original_S_corrected * Eigen::Vector3d{point.x, point.y, point.z};
+    point.x = pointTransformed[0];
+    point.y = pointTransformed[1];
+    point.z = pointTransformed[2];
+
     point_counter++;
   }
   return true;

--- a/lidar_undistortion/include/lidar_undistortion/pose_buffer.hpp
+++ b/lidar_undistortion/include/lidar_undistortion/pose_buffer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <Eigen/Dense>
+#include <Eigen/Geometry>
 #include <map>
 
 class PoseBuffer {

--- a/lidar_undistortion/src/pose_buffer.cpp
+++ b/lidar_undistortion/src/pose_buffer.cpp
@@ -73,10 +73,11 @@ bool PoseBuffer::getInterpolatedPose(const uint64_t &nsec,
   --it_low;
 
   // alpha is 1 if the requested time coincides with it_low, 0 if equal to it_high
-  double alpha = (double)(it_high->first - nsec) / (double)(it_high->first - it_low->first);
+  const double alpha = static_cast<double>(it_high->first - nsec) /
+                       static_cast<double>(it_high->first - it_low->first);
 
-  Eigen::Isometry3d iso_low = it_low->second;
-  Eigen::Isometry3d iso_high = it_high->second;
+  const Eigen::Isometry3d iso_low = it_low->second;
+  const Eigen::Isometry3d iso_high = it_high->second;
 
   pose.setIdentity();
 

--- a/lidar_undistortion/test/ouster_undistortion_test.cpp
+++ b/lidar_undistortion/test/ouster_undistortion_test.cpp
@@ -2,6 +2,7 @@
 #include "lidar_undistortion/ouster_image_converter.hpp"
 #include "lidar_undistortion/ouster_point.hpp"
 #include <gtest/gtest.h>
+#include <pcl/io/pcd_io.h>
 #include <pwd.h>
 
 using namespace pcl::io;


### PR DESCRIPTION
1. Remove excess headers, saving 12 seconds compile time on `vilens_anymal`
2. Simplify `transformPoint` function to avoid so many cast operations.
3. Precompute inverse of transformation matrix.
4. Don't add poses to history - probably never required since we never reprocess old scans. Save 25% computation time (23ms to 17ms for a Velodyne scan)